### PR TITLE
fix: Mainnet compatibility

### DIFF
--- a/app/src/components/FaucetButton.tsx
+++ b/app/src/components/FaucetButton.tsx
@@ -14,11 +14,12 @@ export function FaucetButton() {
     const variables = useNetworkVariables();
 
     const recipient = currentAccount?.address;
+    const isFaucetEnabled = !!variables.faucet;
 
     const { mutateAsync: requestFaucet, isPending } = useMutation({
         mutationKey: ['faucet-funds', recipient],
         async mutationFn() {
-            if (recipient) {
+            if (recipient && isFaucetEnabled) {
                 await requestIotaFromFaucetV0({
                     host: variables.faucet,
                     recipient,
@@ -32,6 +33,10 @@ export function FaucetButton() {
             toast.error('Something went wrong while requesting funds.');
         },
     });
+
+    if(!isFaucetEnabled) {
+        return null;
+    }
 
     return (
         <Button

--- a/app/src/components/FaucetButton.tsx
+++ b/app/src/components/FaucetButton.tsx
@@ -34,7 +34,7 @@ export function FaucetButton() {
         },
     });
 
-    if(!isFaucetEnabled) {
+    if (!isFaucetEnabled) {
         return null;
     }
 

--- a/app/src/components/deposit/DepositForm.tsx
+++ b/app/src/components/deposit/DepositForm.tsx
@@ -93,23 +93,17 @@ export function DepositForm({
     const receivingAmountDisplay = (() => {
         if (!depositAmountValue || !gasEstimation) {
             return PLACEHOLDER_VALUE_DISPLAY;
-        } else if (isPayingAllBalance) {
-            const receivingAmount = new BigNumber(depositAmountValue)
-                .minus(gasEstimation)
-                .minus(
-                    isFromLayer1
-                        ? formatIOTAFromNanos(L2_FROM_L1_GAS_BUDGET)
-                        : formatIOTAFromNanos(L1_FROM_L2_GAS_BUDGET),
-                );
-            return receivingAmount.isLessThanOrEqualTo(0) ? null : receivingAmount.toString();
-        } else {
-            const receivingAmount = new BigNumber(depositAmountValue).minus(
+        }
+        const receivingAmount = new BigNumber(depositAmountValue)
+            .minus(isPayingAllBalance && gasEstimation ? gasEstimation : 0)
+            .minus(
                 isFromLayer1
                     ? formatIOTAFromNanos(L2_FROM_L1_GAS_BUDGET)
                     : formatIOTAFromNanos(L1_FROM_L2_GAS_BUDGET),
             );
-            return receivingAmount.isLessThanOrEqualTo(0) ? null : receivingAmount.toString();
-        }
+        return receivingAmount.isLessThanOrEqualTo(0)
+            ? PLACEHOLDER_VALUE_DISPLAY
+            : receivingAmount.toString();
     })();
 
     const fromAddress = isFromLayer1 ? layer1Account?.address : layer2Account?.address;

--- a/app/src/components/deposit/DepositForm.tsx
+++ b/app/src/components/deposit/DepositForm.tsx
@@ -25,7 +25,7 @@ import { Loader, SwapAccount } from '@iota/apps-ui-icons';
 import { useGetCurrentAvailableBalance } from '../../hooks/useGetCurrentAvailableBalance';
 import { useIsBridgingAllBalance } from '../../hooks/useIsBridgingAllBalance';
 import { formatIOTAFromNanos } from '../../lib/utils';
-import { L2_GAS_BUDGET } from 'isc-client';
+import { L1_FROM_L2_GAS_BUDGET, L2_FROM_L1_GAS_BUDGET } from 'isc-client';
 
 interface DepositFormProps {
     deposit: () => void;
@@ -96,10 +96,19 @@ export function DepositForm({
         } else if (isPayingAllBalance) {
             const receivingAmount = new BigNumber(depositAmountValue)
                 .minus(gasEstimation)
-                .minus(formatIOTAFromNanos(L2_GAS_BUDGET));
+                .minus(
+                    isFromLayer1
+                        ? formatIOTAFromNanos(L2_FROM_L1_GAS_BUDGET)
+                        : formatIOTAFromNanos(L1_FROM_L2_GAS_BUDGET),
+                );
             return receivingAmount.isLessThanOrEqualTo(0) ? null : receivingAmount.toString();
         } else {
-            return depositAmountValue;
+            const receivingAmount = new BigNumber(depositAmountValue).minus(
+                isFromLayer1
+                    ? formatIOTAFromNanos(L2_FROM_L1_GAS_BUDGET)
+                    : formatIOTAFromNanos(L1_FROM_L2_GAS_BUDGET),
+            );
+            return receivingAmount.isLessThanOrEqualTo(0) ? null : receivingAmount.toString();
         }
     })();
 

--- a/app/src/components/deposit/layer1/DepositLayer1.tsx
+++ b/app/src/components/deposit/layer1/DepositLayer1.tsx
@@ -11,7 +11,7 @@ import { formatIOTAFromNanos } from '../../../lib/utils';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { DepositFormData } from '../../../lib/schema/bridgeForm.schema';
-import { L2_FROM_L1_GAS_BUDGET } from 'isc-client';
+import { L1_BASE_GAS_BUDGET } from 'isc-client';
 import { useL2BalanceBaseToken } from '../../../hooks/useL2BalanceBaseToken';
 
 export function DepositLayer1() {
@@ -25,18 +25,22 @@ export function DepositLayer1() {
     const { data: l1BalanceInL2 } = useL2BalanceBaseToken(address);
     console.log('l1BalanceInL2:', l1BalanceInL2);
 
-    const [gasEstimation, setGasEstimation] = useState<string>(L2_FROM_L1_GAS_BUDGET.toString());
+    const [gasEstimation, setGasEstimation] = useState<string>(L1_BASE_GAS_BUDGET.toString());
 
-    const { data: transactionData, isPending: isBuildingTransaction } =
-        useBuildL1DepositTransaction({
-            receivingAddress,
-            amount: depositAmount,
-            gasEstimation,
-        });
+    const {
+        data: transactionData,
+        isPending: isBuildingTransaction,
+        error: aaa,
+    } = useBuildL1DepositTransaction({
+        receivingAddress,
+        amount: depositAmount,
+        gasEstimation,
+    });
     const gasSummary = transactionData?.gasSummary;
     const formattedGasEstimation = gasSummary?.totalGas
         ? formatIOTAFromNanos(BigInt(gasSummary.totalGas))
         : undefined;
+    console.log('error', aaa);
 
     useEffect(() => {
         const gasBudget = transactionData?.gasSummary?.budget;

--- a/app/src/components/deposit/layer1/DepositLayer1.tsx
+++ b/app/src/components/deposit/layer1/DepositLayer1.tsx
@@ -27,20 +27,16 @@ export function DepositLayer1() {
 
     const [gasEstimation, setGasEstimation] = useState<string>(L1_BASE_GAS_BUDGET.toString());
 
-    const {
-        data: transactionData,
-        isPending: isBuildingTransaction,
-        error: aaa,
-    } = useBuildL1DepositTransaction({
-        receivingAddress,
-        amount: depositAmount,
-        gasEstimation,
-    });
+    const { data: transactionData, isPending: isBuildingTransaction } =
+        useBuildL1DepositTransaction({
+            receivingAddress,
+            amount: depositAmount,
+            gasEstimation,
+        });
     const gasSummary = transactionData?.gasSummary;
     const formattedGasEstimation = gasSummary?.totalGas
         ? formatIOTAFromNanos(BigInt(gasSummary.totalGas))
         : undefined;
-    console.log('error', aaa);
 
     useEffect(() => {
         const gasBudget = transactionData?.gasSummary?.budget;

--- a/app/src/components/deposit/layer1/DepositLayer1.tsx
+++ b/app/src/components/deposit/layer1/DepositLayer1.tsx
@@ -11,7 +11,7 @@ import { formatIOTAFromNanos } from '../../../lib/utils';
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { DepositFormData } from '../../../lib/schema/bridgeForm.schema';
-import { L1_GAS_BUDGET } from 'isc-client';
+import { L2_FROM_L1_GAS_BUDGET } from 'isc-client';
 import { useL2BalanceBaseToken } from '../../../hooks/useL2BalanceBaseToken';
 
 export function DepositLayer1() {
@@ -25,7 +25,7 @@ export function DepositLayer1() {
     const { data: l1BalanceInL2 } = useL2BalanceBaseToken(address);
     console.log('l1BalanceInL2:', l1BalanceInL2);
 
-    const [gasEstimation, setGasEstimation] = useState<string>(L1_GAS_BUDGET.toString());
+    const [gasEstimation, setGasEstimation] = useState<string>(L2_FROM_L1_GAS_BUDGET.toString());
 
     const { data: transactionData, isPending: isBuildingTransaction } =
         useBuildL1DepositTransaction({

--- a/app/src/components/deposit/layer2/DepositLayer2.tsx
+++ b/app/src/components/deposit/layer2/DepositLayer2.tsx
@@ -47,32 +47,37 @@ export function DepositLayer2() {
     });
 
     const { data: gasEstimation, isPending: isGasEstimationLoading } = useQuery({
-        queryKey: ['l2-deposit-transaction-gas-estimate', receivingAddress, iscContractAddress],
+        queryKey: [
+            'l2-deposit-transaction-gas-estimate',
+            receivingAddress,
+            iscContractAddress,
+            depositAmount,
+        ],
         async queryFn() {
-            if (receivingAddress && iscContractAddress) {
-                const params = buildDepositL2Parameters(
-                    receivingAddress,
-                    MINIMUM_SEND_AMOUNT.toString(),
-                );
-                const gas = await client?.estimateContractGas({
-                    address: iscContractAddress,
-                    abi: iscAbi,
-                    functionName: 'transferToL1',
-                    args: params,
-                    account: layer2Account.address,
-                });
-
-                let gasPrice = await client?.getGasPrice();
-
-                if (!gasPrice) {
-                    gasPrice = 10n;
-                } else {
-                    gasPrice = BigInt(formatGwei(gasPrice));
-                }
-
-                return gas ? formatGwei(BigInt(gas * gasPrice)) : null;
+            if (!receivingAddress || !iscContractAddress) {
+                return null;
             }
-            return null;
+            const params = buildDepositL2Parameters(
+                receivingAddress,
+                MINIMUM_SEND_AMOUNT.toString(),
+            );
+            const gas = await client?.estimateContractGas({
+                address: iscContractAddress,
+                abi: iscAbi,
+                functionName: 'transferToL1',
+                args: params,
+                account: layer2Account.address,
+            });
+
+            let gasPrice = await client?.getGasPrice();
+
+            if (!gasPrice) {
+                gasPrice = 10n;
+            } else {
+                gasPrice = BigInt(formatGwei(gasPrice));
+            }
+
+            return gas ? formatGwei(BigInt(gas * gasPrice)) : null;
         },
         refetchInterval: 2000,
     });

--- a/app/src/components/deposit/layer2/DepositLayer2.tsx
+++ b/app/src/components/deposit/layer2/DepositLayer2.tsx
@@ -47,14 +47,9 @@ export function DepositLayer2() {
     });
 
     const { data: gasEstimation, isPending: isGasEstimationLoading } = useQuery({
-        queryKey: [
-            'l2-deposit-transaction-gas-estimate',
-            receivingAddress,
-            depositAmount,
-            iscContractAddress,
-        ],
+        queryKey: ['l2-deposit-transaction-gas-estimate', receivingAddress, iscContractAddress],
         async queryFn() {
-            if (receivingAddress && depositAmount && iscContractAddress) {
+            if (receivingAddress && iscContractAddress) {
                 const params = buildDepositL2Parameters(
                     receivingAddress,
                     MINIMUM_SEND_AMOUNT.toString(),

--- a/app/src/components/deposit/layer2/DepositLayer2.tsx
+++ b/app/src/components/deposit/layer2/DepositLayer2.tsx
@@ -135,7 +135,10 @@ export function DepositLayer2() {
                 throw Error('Transaction is missing');
             }
 
-            const depositTotal = new BigNumber(depositAmount).minus(gasEstimation!).toString();
+            const depositTotal =
+                isPayingAllBalance && gasEstimation
+                    ? new BigNumber(depositAmount).minus(gasEstimation).toString()
+                    : depositAmount;
             const params = buildDepositL2Parameters(receivingAddress, depositTotal);
 
             await writeContractAsync({

--- a/app/src/config/config.schema.ts
+++ b/app/src/config/config.schema.ts
@@ -7,7 +7,7 @@ export const envSchema = z.record(
         L1: z.object({
             networkName: z.string(),
             rpcUrl: z.string().url(),
-            faucetUrl: z.string().url(),
+            faucetUrl: z.string().url().optional(),
             chainId: z.string(),
             packageId: z.string(),
             accountsContract: z

--- a/app/src/hooks/useBuildL1DepositTransaction.ts
+++ b/app/src/hooks/useBuildL1DepositTransaction.ts
@@ -80,5 +80,6 @@ export function useBuildL1DepositTransaction({
                 gasSummary: getGasSummary(txDryRun),
             };
         },
+        refetchInterval: 2000,
     });
 }

--- a/app/src/hooks/useBuildL1DepositTransaction.ts
+++ b/app/src/hooks/useBuildL1DepositTransaction.ts
@@ -7,7 +7,7 @@ import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 import { IOTA_DECIMALS } from '@iota/iota-sdk/utils';
 import { useNetworkVariables } from '../config';
 import { useIsBridgingAllBalance } from './useIsBridgingAllBalance';
-import { L2_GAS_BUDGET } from 'isc-client';
+import { L2_FROM_L1_GAS_BUDGET } from 'isc-client';
 
 interface BuildL1DepositTransaction {
     receivingAddress: string;
@@ -43,9 +43,9 @@ export function useBuildL1DepositTransaction({
 
             const amountToSend =
                 isBridgingAllBalance && gasEstimation
-                    ? requestedAmount - BigInt(gasEstimation) - L2_GAS_BUDGET
+                    ? requestedAmount - BigInt(gasEstimation) - L2_FROM_L1_GAS_BUDGET
                     : requestedAmount;
-            const amountToPlace = amountToSend + L2_GAS_BUDGET;
+            const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
             const iscTx = new IscTransaction(variables.chain);
             const bag = iscTx.newBag();

--- a/app/src/hooks/useGetCurrentAvailableBalance.ts
+++ b/app/src/hooks/useGetCurrentAvailableBalance.ts
@@ -19,6 +19,9 @@ export function useGetCurrentAvailableBalance(): {
     );
     const { data: layer2Balance, isLoading: isLoadingL2 } = useBalanceL2({
         address: layer2Account?.address,
+        query: {
+            refetchInterval: 2000,
+        },
     });
 
     if ((isFromLayer1 && isLoadingL1) || (!isFromLayer1 && isLoadingL2)) {

--- a/app/src/lib/constants/bridge.constants.ts
+++ b/app/src/lib/constants/bridge.constants.ts
@@ -3,3 +3,4 @@ export const PLACEHOLDER_VALUE_DISPLAY = '--';
 export const IOTA_EVM_DECIMALS = 18;
 export const L1_USER_REJECTED_TX_ERROR_TEXT = 'Rejected from user';
 export const L2_USER_REJECTED_TX_ERROR_TEXT = 'User rejected';
+export const MINIMUM_SEND_AMOUNT = 0.1;

--- a/app/src/lib/schema/bridgeForm.schema.ts
+++ b/app/src/lib/schema/bridgeForm.schema.ts
@@ -4,6 +4,7 @@ import { parseAmount } from '../utils';
 import { isAddress, parseEther } from 'viem';
 import { isValidIotaAddress } from '@iota/iota-sdk/utils';
 import BigNumber from 'bignumber.js';
+import { MINIMUM_SEND_AMOUNT } from '../constants';
 
 export function createBridgeFormSchema(
     totalAccountBalance: bigint,
@@ -17,7 +18,7 @@ export function createBridgeFormSchema(
                 .trim()
                 .refine(
                     (value) => {
-                        return new BigNumber(value).isGreaterThanOrEqualTo(0.01);
+                        return new BigNumber(value).isGreaterThanOrEqualTo(MINIMUM_SEND_AMOUNT);
                     },
                     {
                         message: 'Invalid amount',

--- a/app/src/lib/utils/depositL2Parameters.ts
+++ b/app/src/lib/utils/depositL2Parameters.ts
@@ -8,7 +8,7 @@ export function buildDepositL2Parameters(receiverAddress: string, baseTokensToWi
         {
             coins: [
                 {
-                    coinType: '0x2::iota::IOTA',
+                    coinType: '0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA',
                     amount: convertedBaseToken,
                 },
                 // Put additional native tokens here with the proper coin type and value

--- a/app/src/lib/utils/depositL2Parameters.ts
+++ b/app/src/lib/utils/depositL2Parameters.ts
@@ -8,7 +8,8 @@ export function buildDepositL2Parameters(receiverAddress: string, baseTokensToWi
         {
             coins: [
                 {
-                    coinType: '0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA',
+                    coinType:
+                        '0x0000000000000000000000000000000000000000000000000000000000000002::iota::IOTA',
                     amount: convertedBaseToken,
                 },
                 // Put additional native tokens here with the proper coin type and value

--- a/app/tests/depositThenWithdraw.spec.ts
+++ b/app/tests/depositThenWithdraw.spec.ts
@@ -101,7 +101,7 @@ test.describe.serial('Deposit then withdraw roundtrip', () => {
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(youReceiveValue).toEqual('5');
+        expect(youReceiveValue).toEqual('4.999');
 
         await expect(pageWithL1Wallet.getByText('Bridge Assets')).toBeEnabled();
         await pageWithL1Wallet.getByText('Bridge Assets').click();
@@ -162,14 +162,14 @@ test.describe.serial('Deposit then withdraw roundtrip', () => {
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(Number(gasFeeValue).toFixed(6)).toEqual('0.000036');
+        expect(Number(gasFeeValue).toFixed(6)).toEqual('0.000370');
 
         const youReceiveValue = await pageWithL2Wallet
             .locator('div:has(> span:text("You Receive"))')
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(youReceiveValue).toEqual('2');
+        expect(youReceiveValue).toEqual('1.99');
 
         await expect(pageWithL2Wallet.getByText('Bridge Assets')).toBeEnabled();
 

--- a/app/tests/sendMaxAmount.spec.ts
+++ b/app/tests/sendMaxAmount.spec.ts
@@ -69,7 +69,7 @@ test.describe('Send MAX amount from L1', () => {
         await expect(amountField).toHaveValue('~ 10');
 
         // check est. gas fees and your receive
-        await testPageL1.waitForTimeout(5500);
+        await testPageL1.waitForTimeout(2500);
 
         const gasFeeValue = await testPageL1
             .locator('div:has(> span:text("Est. Gas Fees"))')

--- a/app/tests/sendMaxAmount.spec.ts
+++ b/app/tests/sendMaxAmount.spec.ts
@@ -69,7 +69,7 @@ test.describe('Send MAX amount from L1', () => {
         await expect(amountField).toHaveValue('~ 10');
 
         // check est. gas fees and your receive
-        await testPageL1.waitForTimeout(2500);
+        await testPageL1.waitForTimeout(5500);
 
         const gasFeeValue = await testPageL1
             .locator('div:has(> span:text("Est. Gas Fees"))')
@@ -180,14 +180,14 @@ test.describe('Send MAX amount from L2', () => {
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(Number(gasFeeValue).toFixed(6)).toEqual('0.000032');
+        expect(Number(gasFeeValue).toFixed(6)).toEqual('0.000370');
 
         const youReceiveValue = await testPageL2
             .locator('div:has(> span:text("You Receive"))')
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(Number(youReceiveValue).toFixed(6)).toEqual('8.998968');
+        expect(Number(youReceiveValue).toFixed(6)).toEqual('8.989630');
 
         await expect(testPageL2.getByText('Bridge Assets')).toBeEnabled();
 
@@ -199,6 +199,6 @@ test.describe('Send MAX amount from L2', () => {
 
         const l1Balance = await checkL1BalanceWithRetries(addressL1);
 
-        expect(Number(l1Balance).toFixed(6)).toEqual('8.999968');
+        expect(Number(l1Balance).toFixed(6)).toEqual('8.999630');
     });
 });

--- a/app/tests/sendMaxAmount.spec.ts
+++ b/app/tests/sendMaxAmount.spec.ts
@@ -83,7 +83,7 @@ test.describe('Send MAX amount from L1', () => {
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(Number(youReceiveValue).toFixed(6)).toEqual('9.993268');
+        expect(Number(youReceiveValue).toFixed(6)).toEqual('9.992368');
 
         await expect(testPageL1.getByText('Bridge Assets')).toBeEnabled();
         await testPageL1.getByText('Bridge Assets').click();
@@ -94,7 +94,7 @@ test.describe('Send MAX amount from L1', () => {
 
         const balance = await checkL2BalanceWithRetries(addressL2);
 
-        expect(balance).toEqual('9.991288');
+        expect(balance).toEqual('9.990388');
     });
 });
 
@@ -187,7 +187,7 @@ test.describe('Send MAX amount from L2', () => {
             .locator('xpath=../div/span')
             .nth(1)
             .textContent();
-        expect(Number(youReceiveValue).toFixed(6)).toEqual('8.999868');
+        expect(Number(youReceiveValue).toFixed(6)).toEqual('8.998968');
 
         await expect(testPageL2.getByText('Bridge Assets')).toBeEnabled();
 

--- a/app/tests/utils/utils.ts
+++ b/app/tests/utils/utils.ts
@@ -1,7 +1,7 @@
 import { ethers, Wallet, HDNodeWallet, JsonRpcProvider } from 'ethers';
 import { BrowserContext, Page } from '@playwright/test';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
-import { IscTransaction, L2_GAS_BUDGET } from 'isc-client';
+import { IscTransaction, L2_FROM_L1_GAS_BUDGET } from 'isc-client';
 import { IotaClient } from '@iota/iota-sdk/client';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
@@ -97,12 +97,12 @@ export async function fundL2AddressWithIscClient(addressL2: string, amount: numb
     const address = keypair.toIotaAddress();
 
     await requestIotaFromFaucetV0({
-        host: L1.faucetUrl,
+        host: L1.faucetUrl!,
         recipient: address,
     });
 
     const amountToSend = BigInt(amount * 1000000000);
-    const amountToPlace = amountToSend + L2_GAS_BUDGET;
+    const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
     const iscTx = new IscTransaction(L1);
 

--- a/sdk/examples/L1AddressL2funds.ts
+++ b/sdk/examples/L1AddressL2funds.ts
@@ -2,7 +2,7 @@ import { IotaClient } from '@iota/iota-sdk/client';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { CONFIG } from './config';
-import { EvmRpcClient, IscTransaction, L2_GAS_BUDGET } from '../src';
+import { EvmRpcClient, IscTransaction, L2_FROM_L1_GAS_BUDGET } from '../src';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 
 const { L1, L2 } = CONFIG;

--- a/sdk/examples/anchor.ts
+++ b/sdk/examples/anchor.ts
@@ -1,4 +1,4 @@
-import { IscTransaction, L2_GAS_BUDGET } from '../src/index';
+import { IscTransaction, L2_FROM_L1_GAS_BUDGET } from '../src/index';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
 import { IotaClient } from '@iota/iota-sdk/client';
@@ -28,7 +28,7 @@ const recipientAddress = process.argv[2];
 // Amount to send (1 IOTAs)
 const amountToSend = BigInt(1 * 1000000000);
 // We also need to place a little more in the bag to cover the L2 gas
-const amountToPlace = amountToSend + L2_GAS_BUDGET;
+const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
 const iscTx = new IscTransaction(L1);
 

--- a/sdk/examples/assetsBag.ts
+++ b/sdk/examples/assetsBag.ts
@@ -1,4 +1,4 @@
-import { IscTransaction, L2_GAS_BUDGET } from '../src/index';
+import { IscTransaction, L2_FROM_L1_GAS_BUDGET } from '../src/index';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
@@ -28,7 +28,7 @@ const recipientAddress = process.argv[2];
 // Amount to send (1 IOTAs)
 const amountToSend = BigInt(1 * 1000000000);
 // We also need to place a little more in the bag to cover the L2 gas
-const amountToPlace = amountToSend + L2_GAS_BUDGET;
+const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
 const iscTx = new IscTransaction(L1);
 

--- a/sdk/examples/config.ts
+++ b/sdk/examples/config.ts
@@ -11,7 +11,7 @@ const envSchema = z.record(
         L1: z.object({
             networkName: z.string(),
             rpcUrl: z.string().url(),
-            faucetUrl: z.string().url().optional(),
+            faucetUrl: z.string().url(),
             chainId: z.string(),
             packageId: z.string(),
             accountsContract: z

--- a/sdk/examples/config.ts
+++ b/sdk/examples/config.ts
@@ -11,7 +11,7 @@ const envSchema = z.record(
         L1: z.object({
             networkName: z.string(),
             rpcUrl: z.string().url(),
-            faucetUrl: z.string().url(),
+            faucetUrl: z.string().url().optional(),
             chainId: z.string(),
             packageId: z.string(),
             accountsContract: z

--- a/sdk/examples/tokens.ts
+++ b/sdk/examples/tokens.ts
@@ -1,4 +1,4 @@
-import { EvmRpcClient, IscTransaction, L2_GAS_BUDGET } from '../src/index';
+import { EvmRpcClient, IscTransaction, L2_FROM_L1_GAS_BUDGET } from '../src/index';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { IotaClient } from '@iota/iota-sdk/client';
@@ -33,7 +33,7 @@ const amountToSend = BigInt(1 * 1_000_000);
 // Amount to send (1 Boxfish)
 const tokenAmountToSend = BigInt(1);
 // We also need to place a little more in the bag to cover the L2 gas
-const amountToPlace = amountToSend + L2_GAS_BUDGET;
+const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
 console.log('Sending...');
 

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -1,2 +1,2 @@
 export const L1_GAS_BUDGET = 10000000n;
-export const L2_GAS_BUDGET = 100000n;
+export const L2_GAS_BUDGET = 1000000n;

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -1,2 +1,4 @@
-export const L1_GAS_BUDGET = 10000000n;
-export const L2_GAS_BUDGET = 1000000n;
+// Gas used in L1 when sending from L2
+export const L1_FROM_L2_GAS_BUDGET = 10000000n;
+// Gas used in L2 when sending from L1
+export const L2_FROM_L1_GAS_BUDGET = 1000000n;

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -1,3 +1,5 @@
+// Base gas used in L1 when sending from L1
+export const L1_BASE_GAS_BUDGET = 10000000n;
 // Gas used in L1 when sending from L2
 export const L1_FROM_L2_GAS_BUDGET = 10000000n;
 // Gas used in L2 when sending from L1

--- a/sdk/src/transaction.ts
+++ b/sdk/src/transaction.ts
@@ -2,7 +2,7 @@ import { Transaction, TransactionObjectArgument } from '@iota/iota-sdk/transacti
 import * as isc from './isc';
 import { ChainData } from './types';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
-import { L2_GAS_BUDGET } from './constants';
+import { L2_FROM_L1_GAS_BUDGET } from './constants';
 import type { ObjectArgument } from './isc';
 
 export type Agent = {
@@ -77,7 +77,7 @@ export class IscTransaction {
         contractFunction,
         contractArgs,
         transfers,
-        gasBudget = L2_GAS_BUDGET,
+        gasBudget = L2_FROM_L1_GAS_BUDGET,
     }: {
         contractArgs: Uint8Array[];
         contract: number;
@@ -107,7 +107,7 @@ export class IscTransaction {
         accountsContract,
         accountsFunction,
         transfers,
-        gasBudget = L2_GAS_BUDGET,
+        gasBudget = L2_FROM_L1_GAS_BUDGET,
         bag,
     }: {
         address: string;

--- a/sdk/tests/L1ToL2Tokens.spec.ts
+++ b/sdk/tests/L1ToL2Tokens.spec.ts
@@ -1,4 +1,4 @@
-import { EvmRpcClient, IscTransaction, L2_GAS_BUDGET } from '../src/index';
+import { EvmRpcClient, IscTransaction, L2_FROM_L1_GAS_BUDGET } from '../src/index';
 import { IOTA_TYPE_ARG } from '@iota/iota-sdk/utils';
 import { Ed25519Keypair } from '@iota/iota-sdk/keypairs/ed25519';
 import { requestIotaFromFaucetV0 } from '@iota/iota-sdk/faucet';
@@ -23,7 +23,7 @@ test('Send IOTA', async () => {
     const address = keypair.toIotaAddress();
 
     await requestIotaFromFaucetV0({
-        host: L1.faucetUrl,
+        host: L1.faucetUrl!,
         recipient: address,
     });
 
@@ -34,7 +34,7 @@ test('Send IOTA', async () => {
     // Amount to send (1 IOTAs)
     const amountToSend = BigInt(1 * 1000000000);
     // We also need to place a little more in the bag to cover the L2 gas
-    const amountToPlace = amountToSend + L2_GAS_BUDGET;
+    const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
     const iscTx = new IscTransaction(L1);
 
@@ -84,7 +84,7 @@ test('Send Non-IOTA Tokens', async () => {
     // Amount to send (1 Boxfish)
     const tokenAmountToSend = BigInt(1);
     // We also need to place a little more in the bag to cover the L2 gas
-    const amountToPlace = amountToSend + L2_GAS_BUDGET;
+    const amountToPlace = amountToSend + L2_FROM_L1_GAS_BUDGET;
 
     const iscTx = new IscTransaction(L1);
     const tx = iscTx.transaction();

--- a/sdk/tests/config.ts
+++ b/sdk/tests/config.ts
@@ -11,7 +11,7 @@ const envSchema = z.record(
         L1: z.object({
             networkName: z.string(),
             rpcUrl: z.string().url(),
-            faucetUrl: z.string().url().optional(),
+            faucetUrl: z.string().url(),
             chainId: z.string(),
             packageId: z.string(),
             accountsContract: z

--- a/sdk/tests/config.ts
+++ b/sdk/tests/config.ts
@@ -11,7 +11,7 @@ const envSchema = z.record(
         L1: z.object({
             networkName: z.string(),
             rpcUrl: z.string().url(),
-            faucetUrl: z.string().url(),
+            faucetUrl: z.string().url().optional(),
             chainId: z.string(),
             packageId: z.string(),
             accountsContract: z


### PR DESCRIPTION
- general: Make faucet optional
- general: Always deduct destination chain gas in the UI
- general: Change the minimum send amount from 0.01 to 0.1
- EVM: Fixed amount of 0.1 is now used to calculate gas estimation in EVM
- EVM: Automatically refetch EVM account balance every 2s
- general: Automatically recompute L1 and L2 gas estimation every 2s
- EVM: Compute EVM the gas estimation also considering the gas price
- general: Update tests to match the new fee policy in Testnet
- general: Renamed constants to make their use more clear

:godmode: 